### PR TITLE
Include closing } in panos config

### DIFF
--- a/lib/panos.pm.in
+++ b/lib/panos.pm.in
@@ -144,6 +144,7 @@ sub ShowConfig {
 	tr/\015//d;
 	if (/^}\s*$|\[edit\]/) {
 	    $found_end = 1;
+	    ProcessHistory("","","","$_");
 	    return(1);
 	}
 


### PR DESCRIPTION
PanOS ShowConfig dropped the final closing brace in configs.  This
ensures that when we hit the end of the config, the closing brace is
included, so the resulting saved config is pedantically complete.